### PR TITLE
An example of using `semistandard`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Mac
 .DS_Store
+
+# npm
+node_modules

--- a/package.json
+++ b/package.json
@@ -6,6 +6,13 @@
     "type": "git",
     "url": "https://github.com/phonegap/phonegap-app-hello-world.git"
   },
+  "devDependencies": {
+    "semistandard": "^8.0.0",
+    "snazzy": "^4.0.0"
+  },
+  "scripts": {
+    "test": "semistandard www/**/*.js | snazzy"
+  },
   "author": "PhoneGap Team",
   "license": "Apache-2.0.0",
   "keywords": [

--- a/www/js/index.js
+++ b/www/js/index.js
@@ -17,33 +17,33 @@
  * under the License.
  */
 var app = {
-    // Application Constructor
-    initialize: function() {
-        this.bindEvents();
-    },
-    // Bind Event Listeners
-    //
-    // Bind any events that are required on startup. Common events are:
-    // 'load', 'deviceready', 'offline', and 'online'.
-    bindEvents: function() {
-        document.addEventListener('deviceready', this.onDeviceReady, false);
-    },
-    // deviceready Event Handler
-    //
-    // The scope of 'this' is the event. In order to call the 'receivedEvent'
-    // function, we must explicitly call 'app.receivedEvent(...);'
-    onDeviceReady: function() {
-        app.receivedEvent('deviceready');
-    },
-    // Update DOM on a Received Event
-    receivedEvent: function(id) {
-        var parentElement = document.getElementById(id);
-        var listeningElement = parentElement.querySelector('.listening');
-        var receivedElement = parentElement.querySelector('.received');
+  // Application Constructor
+  initialize: function () {
+    this.bindEvents();
+  },
+  // Bind Event Listeners
+  //
+  // Bind any events that are required on startup. Common events are:
+  // 'load', 'deviceready', 'offline', and 'online'.
+  bindEvents: function () {
+    document.addEventListener('deviceready', this.onDeviceReady, false);
+  },
+  // deviceready Event Handler
+  //
+  // The scope of 'this' is the event. In order to call the 'receivedEvent'
+  // function, we must explicitly call 'app.receivedEvent(...);'
+  onDeviceReady: function () {
+    app.receivedEvent('deviceready');
+  },
+  // Update DOM on a Received Event
+  receivedEvent: function (id) {
+    var parentElement = document.getElementById(id);
+    var listeningElement = parentElement.querySelector('.listening');
+    var receivedElement = parentElement.querySelector('.received');
 
-        listeningElement.setAttribute('style', 'display:none;');
-        receivedElement.setAttribute('style', 'display:block;');
+    listeningElement.setAttribute('style', 'display:none;');
+    receivedElement.setAttribute('style', 'display:block;');
 
-        console.log('Received Event: ' + id);
-    }
+    console.log('Received Event: ' + id);
+  }
 };

--- a/www/spec/helper.js
+++ b/www/spec/helper.js
@@ -16,18 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-afterEach(function() {
-    document.getElementById('stage').innerHTML = '';
+/* eslint-env jasmine */
+afterEach(function () {
+  document.getElementById('stage').innerHTML = '';
 });
 
-var helper = {
-    trigger: function(obj, name) {
-        var e = document.createEvent('Event');
-        e.initEvent(name, true, true);
-        obj.dispatchEvent(e);
-    },
-    getComputedStyle: function(querySelector, property) {
-        var element = document.querySelector(querySelector);
-        return window.getComputedStyle(element).getPropertyValue(property);
-    }
+window.helper = {
+  trigger: function (obj, name) {
+    var e = document.createEvent('Event');
+    e.initEvent(name, true, true);
+    obj.dispatchEvent(e);
+  },
+  getComputedStyle: function (querySelector, property) {
+    var element = document.querySelector(querySelector);
+    return window.getComputedStyle(element).getPropertyValue(property);
+  }
 };

--- a/www/spec/index.js
+++ b/www/spec/index.js
@@ -16,52 +16,54 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-describe('app', function() {
-    describe('initialize', function() {
-        it('should bind deviceready', function() {
-            runs(function() {
-                spyOn(app, 'onDeviceReady');
-                app.initialize();
-                helper.trigger(window.document, 'deviceready');
-            });
+/* eslint-env jasmine */
+/* global app helper */
+describe('app', function () {
+  describe('initialize', function () {
+    it('should bind deviceready', function () {
+      runs(function () {
+        spyOn(app, 'onDeviceReady');
+        app.initialize();
+        helper.trigger(window.document, 'deviceready');
+      });
 
-            waitsFor(function() {
-                return (app.onDeviceReady.calls.length > 0);
-            }, 'onDeviceReady should be called once', 500);
+      waitsFor(function () {
+        return (app.onDeviceReady.calls.length > 0);
+      }, 'onDeviceReady should be called once', 500);
 
-            runs(function() {
-                expect(app.onDeviceReady).toHaveBeenCalled();
-            });
-        });
+      runs(function () {
+        expect(app.onDeviceReady).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('onDeviceReady', function () {
+    it('should report that it fired', function () {
+      spyOn(app, 'receivedEvent');
+      app.onDeviceReady();
+      expect(app.receivedEvent).toHaveBeenCalledWith('deviceready');
+    });
+  });
+
+  describe('receivedEvent', function () {
+    beforeEach(function () {
+      var el = document.getElementById('stage');
+      el.innerHTML = ['<div id="deviceready">',
+              '  <p class="event listening">Listening</p>',
+              '  <p class="event received">Received</p>',
+              '</div>'].join('\n');
     });
 
-    describe('onDeviceReady', function() {
-        it('should report that it fired', function() {
-            spyOn(app, 'receivedEvent');
-            app.onDeviceReady();
-            expect(app.receivedEvent).toHaveBeenCalledWith('deviceready');
-        });
+    it('should hide the listening element', function () {
+      app.receivedEvent('deviceready');
+      var displayStyle = helper.getComputedStyle('#deviceready .listening', 'display');
+      expect(displayStyle).toEqual('none');
     });
 
-    describe('receivedEvent', function() {
-        beforeEach(function() {
-            var el = document.getElementById('stage');
-            el.innerHTML = ['<div id="deviceready">',
-                            '    <p class="event listening">Listening</p>',
-                            '    <p class="event received">Received</p>',
-                            '</div>'].join('\n');
-        });
-
-        it('should hide the listening element', function() {
-            app.receivedEvent('deviceready');
-            var displayStyle = helper.getComputedStyle('#deviceready .listening', 'display');
-            expect(displayStyle).toEqual('none');
-        });
-
-        it('should show the received element', function() {
-            app.receivedEvent('deviceready');
-            var displayStyle = helper.getComputedStyle('#deviceready .received', 'display');
-            expect(displayStyle).toEqual('block');
-        });
+    it('should show the received element', function () {
+      app.receivedEvent('deviceready');
+      var displayStyle = helper.getComputedStyle('#deviceready .received', 'display');
+      expect(displayStyle).toEqual('block');
     });
+  });
 });


### PR DESCRIPTION
Includes

1. semistandard - https://github.com/Flet/semistandard
2. snazzy (pretty formatting of errors, not 100% needed)
3. npm script to run semistandard as a test

Also includes the changes this particular repo would need to pass

Pros:

Bolts-included full set of reasonable standards.

Cons:

Not meant to be tweaked for personal preference. Take it or leave it
approach.

A more tweakable way of implementing semistandard as a "base" would be
an eslint config such as https://github.com/Flet/eslint-config-semistandard